### PR TITLE
fix: update Ukrainian locale format from uk_UA to uk-UA

### DIFF
--- a/GitHubRepo/release.ps1
+++ b/GitHubRepo/release.ps1
@@ -23,7 +23,7 @@ foreach ($arch in $archs) {
 		"$releasePath/$assembly.deps.json",
 		"$releasePath/de-DE",
 		"$releasePath/zh-CN",
-		"$ReleasePath/uk_UA"
+		"$ReleasePath/uk-UA"
 	)
 	Copy-Item $items "./out/$name" -Recurse -Force
 	Compress-Archive "./out/$name" "./out/$name-$version-$arch.zip" -Force


### PR DESCRIPTION
Changed the Ukrainian locale format from underscore format (uk_UA) to hyphen format (uk-UA) to comply with ISO language code standards and Microsoft .NET culture naming conventions.

This ensures proper loading of localized resources in the .NET environment and follows the recommended practice for culture identifiers.